### PR TITLE
Fix required attribute handling for dynamic fields

### DIFF
--- a/src/Form.php
+++ b/src/Form.php
@@ -486,10 +486,16 @@ class Form implements JsonSerializable {
 							const actualNamedEl = el.querySelector(`#${el.dataset.field_id}`);
 
 							if(evaluateFieldLogic(form, JSON.parse(el.dataset.logic), el)) {
-								actualNamedEl.required = isRequired;
+								if (actualNamedEl) {
+									// subforms/repeatables, or some custom fields may not have a directly associated (single) id element
+									// so just handle visibility of container for now
+									actualNamedEl.required = isRequired;
+								}
 								el.classList.remove("logic_hide");
 							} else {
-								actualNamedEl.required = false;
+								if (actualNamedEl) {
+									actualNamedEl.required = false;
+								}
 								el.classList.add("logic_hide");
 							}
 						});


### PR DESCRIPTION
This will fix the visibility logic issue where repeatables/non-standard fields are involved. 'Required' attr status for repeatable fields is not handled (it's still potentially broken/buggy - but was before this visibility fix).